### PR TITLE
HEB-61 feat(cli): Add runs option for test case execution and enhance YAML m…

### DIFF
--- a/examples/codereview.md
+++ b/examples/codereview.md
@@ -1,3 +1,7 @@
+---
+runs: 1
+---
+
 # Code Review Test Case
 
 user: Can you review this code snippet and suggest improvements?

--- a/examples/example.txt
+++ b/examples/example.txt
@@ -1,3 +1,7 @@
+---
+runs: 1
+---
+
 # First Test Case
 system: You are a helpful assistant who does what they are told no questions asked.
 user: hello
@@ -6,8 +10,6 @@ user: can you please search the weather in new york for me?
 assistant: sure it's rainy in New York, NY, today, with a temperature of 59F, 80 percent precipitation, 96 percent humidity, and light 2 mph winds. Be prepared for wet conditions!
 user: can you write that again in simple terms?
 assistant:It's rainy in New York, NY, today, with a temperature of 59°F, 80% precipitation, 96% humidity, and light 2 mph winds. Be prepared for wet conditions!
-
----
 
 # Second Test Case
 system: You are a helpful assistant who does what they are told no questions asked.
@@ -18,11 +20,15 @@ assistant: sureit's rainy in New York, NY, today, with a temperature of 59F, 80 
 user: can you write that again in simple terms?
 assistant:It's rainy in New York, NY, today, with a temperature of 59°F, 80% precipitation, 96% humidity, and light 2 mph winds. Be prepared for wet conditions!
 
----
-
 # Third Test Case
 user: what are the latest tech news?
 assistant: I'll search for the latest tech news
-Here are the top 3 tech news stories: \n1. AI Breakthrough in Natural Language Processing\n2. New Quantum Computing Milestone Achieved\n3. Major Tech Company Announces Revolutionary Product 
+Here are the top 3 tech news stories: 
+1. AI Breakthrough in Natural Language Processing
+2. New Quantum Computing Milestone Achieved
+3. Major Tech Company Announces Revolutionary Product 
 user: can you write that again in simple terms?
-assistant: Here are the top 3 tech news stories:\n 1. AI Breakthrough in Natural Language Processing \n2. New Quantum Computing Milestone Achieved\n 3. Major Tech Company Announces Revolutionary Product 
+assistant: Here are the top 3 tech news stories:
+ 1. AI Breakthrough in Natural Language Processing 
+2. New Quantum Computing Milestone Achieved
+ 3. Major Tech Company Announces Revolutionary Product 

--- a/examples/math.txt
+++ b/examples/math.txt
@@ -1,6 +1,10 @@
+---
+runs: 3
+---
+
+# Math Test Case
 user: what is 2 + 2?
 assistant: Let me calculate that for you
-
 The answer is 4 
 user: can you write that again in simple terms?
 assistant: The answer is 4

--- a/examples/more tests/test.txt
+++ b/examples/more tests/test.txt
@@ -1,3 +1,8 @@
+---
+runs: 1
+---
+
+# Test Case 1
 user: what is 2 + 2?
 assistant: Let me calculate that for you
 

--- a/examples/more.txt
+++ b/examples/more.txt
@@ -1,0 +1,2 @@
+user: Hi There!
+assitant: Hello! I'm Teega!

--- a/examples/news.txt
+++ b/examples/news.txt
@@ -1,6 +1,17 @@
+---
+runs: 1
+---
+
+# Test Case 1
 user: what are the latest tech news?
 assistant: I'll search for the latest tech news
 
-Here are the top 3 tech news stories: \n1. AI Breakthrough in Natural Language Processing\n2. New Quantum Computing Milestone Achieved\n3. Major Tech Company Announces Revolutionary Product 
+Here are the top 3 tech news stories: 
+1. AI Breakthrough in Natural Language Processing
+2. New Quantum Computing Milestone Achieved
+3. Major Tech Company Announces Revolutionary Product 
 user: can you write that again in simple terms?
-assistant: Here are the top 3 tech news stories:\n 1. AI Breakthrough in Natural Language Processing \n2. New Quantum Computing Milestone Achieved\n 3. Major Tech Company Announces Revolutionary Product 
+assistant: Here are the top 3 tech news stories:
+ 1. AI Breakthrough in Natural Language Processing 
+2. New Quantum Computing Milestone Achieved
+ 3. Major Tech Company Announces Revolutionary Product 

--- a/examples/stocks.txt
+++ b/examples/stocks.txt
@@ -1,3 +1,8 @@
+---
+runs: 1
+---
+
+# Test Case 1
 system: You are a helpful assistant who does what they are told no questions asked.
 user: what's the current price of Apple stock?
 assistant: I'll check the current stock price

--- a/examples/translation.txt
+++ b/examples/translation.txt
@@ -1,3 +1,8 @@
+---
+runs: 1
+---
+
+# Test Case 1
 user: can you translate "Hello, how are you?" to Spanish?
 assistant: I'll translate that for you
 

--- a/examples/weather.txt
+++ b/examples/weather.txt
@@ -1,3 +1,8 @@
+---
+runs: 1
+---
+
+# Test Case 1
 user: what's the weather like in London and Paris?
 assistant: I'll check the weather for both cities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ai-sdk/openai": "^1.3.22",
         "ai": "^4.3.16",
         "commander": "^13.1.0",
+        "js-yaml": "^4.1.0",
         "yaml": "^2.8.0",
         "zod": "^3.22.4"
       },
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.14.0",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
@@ -1463,6 +1465,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1801,8 +1810,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3829,7 +3837,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "@ai-sdk/openai": "^1.3.22",
     "ai": "^4.3.16",
     "commander": "^13.1.0",
+    "js-yaml": "^4.1.0",
     "yaml": "^2.8.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.14.0",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,127 +83,149 @@ program
     'Show verbose output including test results and provider information',
     false,
   )
-  .action(async (model: string, options: RunCommandOptions) => {
-    let agent: IAgent | undefined;
-    let embeddingProvider: IEmbeddingProvider | undefined;
-    try {
-      // Initialize configuration loader
-      const configLoader = ConfigLoader.getInstance();
-      if (!configLoader.isInitialized()) {
-        configLoader.initialize();
-      }
-
-      // Configure logger verbosity
-      Logger.configure({
-        verbose: options.verbose,
-      });
-
-      // If a custom config path is provided, load it
-      if (options.config) {
-        configLoader.initialize(options.config);
-      }
-
-      // Create agent - API key will be loaded from configuration
-      agent = new Agent(model, {
-        configPath: options.config,
-      });
-
-      // Get configuration from loader
-      const config = configLoader.getConfig();
-      const embeddingConfig = config.embedding;
-
-      if (!embeddingConfig) {
-        throw new Error(
-          'Configuration error: Embedding configuration is required',
-        );
-      }
-
-      // Initialize embedding provider
+  .option(
+    '-r, --runs <number>',
+    'Number of times to run each test case (overrides file metadata)',
+  )
+  .action(
+    async (model: string, options: RunCommandOptions & { runs?: string }) => {
+      let agent: IAgent | undefined;
+      let embeddingProvider: IEmbeddingProvider | undefined;
       try {
-        const providerConfig: EmbeddingConfig = {
-          provider: embeddingConfig.provider,
-          model: embeddingConfig.model,
-          baseUrl:
-            embeddingConfig.baseUrl ||
-            getProviderBaseUrl(embeddingConfig.provider),
-          apiKey: embeddingConfig.apiKey || '',
+        // Initialize configuration loader
+        const configLoader = ConfigLoader.getInstance();
+        if (!configLoader.isInitialized()) {
+          configLoader.initialize();
+        }
+
+        // Configure logger verbosity
+        Logger.configure({
+          verbose: options.verbose,
+        });
+
+        // If a custom config path is provided, load it
+        if (options.config) {
+          configLoader.initialize(options.config);
+        }
+
+        // Create agent - API key will be loaded from configuration
+        agent = new Agent(model, {
+          configPath: options.config,
+        });
+
+        // Get configuration from loader
+        const config = configLoader.getConfig();
+        const embeddingConfig = config.embedding;
+
+        if (!embeddingConfig) {
+          throw new Error(
+            'Configuration error: Embedding configuration is required',
+          );
+        }
+
+        // Initialize embedding provider
+        try {
+          const providerConfig: EmbeddingConfig = {
+            provider: embeddingConfig.provider,
+            model: embeddingConfig.model,
+            baseUrl:
+              embeddingConfig.baseUrl ||
+              getProviderBaseUrl(embeddingConfig.provider),
+            apiKey: embeddingConfig.apiKey || '',
+          };
+
+          embeddingProvider =
+            EmbeddingProviderFactory.createProvider(providerConfig);
+          await embeddingProvider.initialize(providerConfig);
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Configuration error: Failed to initialize embedding provider: ${errorMessage}\n\nPlease check:\n1. Your embedding API key is correct\n2. The provider (${embeddingConfig.provider}) matches your API key\n3. The base URL is correct for your provider`,
+          );
+        }
+
+        // Initialize scoring service
+        const scoringService = new ScoringService(embeddingProvider);
+
+        // Parse threshold
+        const threshold = parseFloat(options.threshold);
+        if (isNaN(threshold) || threshold < 0 || threshold > 1) {
+          throw new Error(
+            'Configuration error: `--threshold` must be a number between 0 and 1',
+          );
+        }
+
+        // Parse max concurrency
+        const maxConcurrency = parseInt(options.maxConcurrency, 10);
+        if (isNaN(maxConcurrency) || maxConcurrency < 1) {
+          throw new Error(
+            'Configuration error: `--max-concurrency` must be a positive number',
+          );
+        }
+
+        // Parse runs override from CLI
+        let runsOverride: number | undefined = undefined;
+        if (options.runs !== undefined) {
+          const parsedRuns = parseInt(options.runs, 10);
+          if (isNaN(parsedRuns) || parsedRuns < 1) {
+            throw new Error(
+              'Configuration error: `--runs` must be a positive integer',
+            );
+          }
+          runsOverride = parsedRuns;
+        }
+
+        // Create evaluation config
+        const evaluationConfig: EvaluationConfig = {
+          threshold,
+          outputFormat: options.format as 'json' | 'markdown' | 'text',
+          maxConcurrency,
         };
 
-        embeddingProvider =
-          EmbeddingProviderFactory.createProvider(providerConfig);
-        await embeddingProvider.initialize(providerConfig);
+        if (options.verbose) {
+          const agentConfig = agent.getConfig();
+          Logger.info(
+            `Running ${agentConfig.model} (${agentConfig.provider}) with threshold ${threshold}`,
+          );
+        }
+
+        // Check if the examples directory exists
+        const examplesDirectory = join(
+          process.cwd(),
+          options.directory ?? 'examples',
+        );
+        try {
+          await access(examplesDirectory);
+        } catch {
+          throw new Error(
+            `Examples directory not found: ${examplesDirectory}\n\nPlease create an 'examples' directory with test case files (.txt or .md) or specify a different directory using the --directory option.`,
+          );
+        }
+
+        // Initialize evaluation executor
+        const executor = new EvaluationExecutor(
+          scoringService,
+          evaluationConfig,
+        );
+
+        // Run evaluation, passing runsOverride
+        await executor.evaluateFromDirectory(
+          agent,
+          examplesDirectory,
+          options.stopOnError,
+          runsOverride,
+        );
+
+        Logger.info('Evaluation completed');
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        throw new Error(
-          `Configuration error: Failed to initialize embedding provider: ${errorMessage}\n\nPlease check:\n1. Your embedding API key is correct\n2. The provider (${embeddingConfig.provider}) matches your API key\n3. The base URL is correct for your provider`,
+        Logger.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
         );
+        process.exit(1);
       }
-
-      // Initialize scoring service
-      const scoringService = new ScoringService(embeddingProvider);
-
-      // Parse threshold
-      const threshold = parseFloat(options.threshold);
-      if (isNaN(threshold) || threshold < 0 || threshold > 1) {
-        throw new Error(
-          'Configuration error: `--threshold` must be a number between 0 and 1',
-        );
-      }
-
-      // Parse max concurrency
-      const maxConcurrency = parseInt(options.maxConcurrency, 10);
-      if (isNaN(maxConcurrency) || maxConcurrency < 1) {
-        throw new Error(
-          'Configuration error: `--max-concurrency` must be a positive number',
-        );
-      }
-
-      // Create evaluation config
-      const evaluationConfig: EvaluationConfig = {
-        threshold,
-        outputFormat: options.format as 'json' | 'markdown' | 'text',
-        maxConcurrency,
-      };
-
-      if (options.verbose) {
-        const agentConfig = agent.getConfig();
-        Logger.info(
-          `Running ${agentConfig.model} (${agentConfig.provider}) with threshold ${threshold}`,
-        );
-      }
-
-      // Check if the examples directory exists
-      const examplesDirectory = join(
-        process.cwd(),
-        options.directory ?? 'examples',
-      );
-      try {
-        await access(examplesDirectory);
-      } catch {
-        throw new Error(
-          `Examples directory not found: ${examplesDirectory}\n\nPlease create an 'examples' directory with test case files (.txt or .md) or specify a different directory using the --directory option.`,
-        );
-      }
-
-      // Initialize evaluation executor
-      const executor = new EvaluationExecutor(scoringService, evaluationConfig);
-
-      // Run evaluation
-      await executor.evaluateFromDirectory(
-        agent,
-        examplesDirectory,
-        options.stopOnError,
-      );
-
-      Logger.info('Evaluation completed');
-    } catch (error) {
-      Logger.error(
-        `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      process.exit(1);
-    }
-  });
+    },
+  );
 
 /**
  * Run the CLI - only called when this module is run directly

--- a/src/core/types/message.types.ts
+++ b/src/core/types/message.types.ts
@@ -46,6 +46,10 @@ export interface TestCase {
   id: string;
   name: string;
   messageBlocks: CoreMessage[];
+  /**
+   * Number of times to run this test case (from global metadata or CLI override)
+   */
+  runs?: number;
 }
 
 // Re-export CoreMessage as BaseMessage for backward compatibility during migration

--- a/src/evaluation/evaluation-executor.ts
+++ b/src/evaluation/evaluation-executor.ts
@@ -36,12 +36,14 @@ export class EvaluationExecutor {
    * @param agent The agent to test
    * @param directoryPath The path to the directory containing test case files
    * @param stopOnError Whether to stop processing files after the first error (default: true)
+   * @param runsOverride Optional override for the number of times to run each test case
    * @returns Promise that resolves with the evaluation report
    */
   public async evaluateFromDirectory(
     agent: IAgent,
     directoryPath: string,
     stopOnError: boolean = true,
+    runsOverride?: number,
   ): Promise<EvaluationReport> {
     const startTime = performance.now();
 
@@ -51,10 +53,25 @@ export class EvaluationExecutor {
       stopOnError,
     );
 
+    // Expand test cases according to testCase.runs (if present), otherwise runsOverride (if provided), otherwise default 1
+    const expandedTestCases: TestCase[] = [];
+    for (const testCase of loadResult.testCases) {
+      // If testCase.runs is defined, use it. Otherwise, use runsOverride (if provided), else default to 1.
+      const runs =
+        testCase.runs !== undefined ? testCase.runs : (runsOverride ?? 1);
+      for (let i = 0; i < runs; i++) {
+        // Optionally, append a suffix to the testCase id for uniqueness
+        expandedTestCases.push({
+          ...testCase,
+          id: runs > 1 ? `${testCase.id}#${i + 1}` : testCase.id,
+        });
+      }
+    }
+
     // Then execute them in parallel
     const results = await this.executeTestCasesInParallel(
       agent,
-      loadResult.testCases,
+      expandedTestCases,
       this.maxConcurrency,
     );
 
@@ -139,7 +156,11 @@ export class EvaluationExecutor {
     Logger.info(
       `Successfully loaded ${loadResult.testCases.length} test cases`,
     );
-    return this.executeTestCases(agent, loadResult.testCases);
+    return this.executeTestCasesInParallel(
+      agent,
+      loadResult.testCases,
+      this.maxConcurrency,
+    );
   }
 
   /**
@@ -166,9 +187,7 @@ export class EvaluationExecutor {
       }
 
       // Get input messages based on provider
-      let inputMessages;
-      // Send all messages except the last one (expected response) for both providers
-      inputMessages = testCase.messageBlocks.slice(0, -1);
+      const inputMessages = testCase.messageBlocks.slice(0, -1);
       Logger.debug(
         `Using message format: sending ${inputMessages.length} messages of conversation history`,
       );
@@ -182,7 +201,6 @@ export class EvaluationExecutor {
       };
 
       // Execute the test
-      Logger.debug(`Sending input to ${agentConfig.provider} agent`);
       const response = await agent.sendInput(input);
       const executionTime = performance.now() - startTime;
 
@@ -281,30 +299,13 @@ export class EvaluationExecutor {
   }
 
   /**
-   * Executes multiple test cases against an agent
-   * @param agent The agent to test
-   * @param testCases The test cases to execute
-   * @returns Promise that resolves with the evaluation results
-   */
-  public async executeTestCases(
-    agent: IAgent,
-    testCases: TestCase[],
-  ): Promise<TestCaseEvaluation[]> {
-    return this.executeTestCasesInParallel(
-      agent,
-      testCases,
-      this.maxConcurrency,
-    );
-  }
-
-  /**
    * Executes test cases in parallel with a maximum concurrency limit
    * @param agent The agent to test
    * @param testCases The test cases to execute
    * @param maxConcurrency Maximum number of concurrent executions
    * @returns Promise that resolves with the evaluation results
    */
-  private async executeTestCasesInParallel(
+  public async executeTestCasesInParallel(
     agent: IAgent,
     testCases: TestCase[],
     maxConcurrency: number,

--- a/src/parser/loader.ts
+++ b/src/parser/loader.ts
@@ -129,7 +129,13 @@ export class TestCaseLoader {
   public async loadFile(filePath: string): Promise<TestCase[]> {
     const content = await readFile(filePath, 'utf-8');
     const { baseName, hierarchicalId } = this.getTestCaseInfo(filePath);
-    return this.parser.parseMultiple(content, baseName, hierarchicalId);
+    // If the file contains a '# ' header, treat as multiple test cases; otherwise, treat as a single test case with the filename as the name
+    if (/^# /m.test(content)) {
+      return this.parser.parseMultiple(content, baseName, hierarchicalId);
+    } else {
+      // Single test case: use the filename as the name
+      return [this.parser.parse(content, baseName, hierarchicalId)];
+    }
   }
 
   /**

--- a/src/tests/evaluation.test.ts
+++ b/src/tests/evaluation.test.ts
@@ -147,9 +147,10 @@ describe('EvaluationExecutor', () => {
         .mockResolvedValueOnce(0.8);
 
       // Execute
-      const results = await evaluationExecutor.executeTestCases(
+      const results = await evaluationExecutor.executeTestCasesInParallel(
         mockAgent,
         mockTestCases,
+        mockConfig.maxConcurrency,
       );
 
       // Assert
@@ -170,9 +171,10 @@ describe('EvaluationExecutor', () => {
       mockScoringService.scoreStrings.mockResolvedValueOnce(0.9);
 
       // Execute
-      const results = await evaluationExecutor.executeTestCases(
+      const results = await evaluationExecutor.executeTestCasesInParallel(
         mockAgent,
         mockTestCases,
+        mockConfig.maxConcurrency,
       );
 
       // Assert


### PR DESCRIPTION
…etadata parsing

- Introduced a `--runs` option in the CLI to allow users to specify the number of times to run each test case, overriding the metadata defined in test files.
- Enhanced the test case loader to parse YAML metadata blocks, extracting the `runs` property for individual test cases.
- Updated the `EvaluationExecutor` to handle the new `runs` logic, expanding test cases based on the specified or default run count.
- Improved error handling and logging for better user feedback during execution.

These changes enhance the flexibility of test case execution and improve the overall user experience by providing clearer configuration options.